### PR TITLE
certs: do not re-create NSS database when requesting service cert

### DIFF
--- a/ipaserver/install/ca.py
+++ b/ipaserver/install/ca.py
@@ -25,6 +25,9 @@ def install_check(standalone, replica_config, options):
     global external_cert_file
     global external_ca_file
 
+    if replica_config is not None and not replica_config.setup_ca:
+        return
+
     realm_name = options.realm_name
     host_name = options.host_name
     subject_base = options.subject
@@ -143,6 +146,7 @@ def install_step_0(standalone, replica_config, options):
         master_host = None
         master_replication_port = None
         ra_p12 = None
+        ra_only = False
         promote = False
     else:
         cafile = os.path.join(replica_config.dir, 'cacert.p12')
@@ -167,13 +171,12 @@ def install_step_0(standalone, replica_config, options):
         master_host = replica_config.ca_host_name
         master_replication_port = replica_config.ca_ds_port
         ra_p12 = os.path.join(replica_config.dir, 'ra.p12')
+        ra_only = not replica_config.setup_ca
         promote = options.promote
 
     ca = cainstance.CAInstance(realm_name, certs.NSS_DIR,
                                host_name=host_name,
                                dm_password=dm_password)
-    if standalone or replica_config is not None:
-        ca.create_ra_agent_db = False
     ca.configure_instance(host_name, dm_password, dm_password,
                           subject_base=subject_base,
                           ca_signing_algorithm=ca_signing_algorithm,
@@ -185,10 +188,14 @@ def install_step_0(standalone, replica_config, options):
                           master_host=master_host,
                           master_replication_port=master_replication_port,
                           ra_p12=ra_p12,
+                          ra_only=ra_only,
                           promote=promote)
 
 
 def install_step_1(standalone, replica_config, options):
+    if replica_config is not None and not replica_config.setup_ca:
+        return
+
     realm_name = options.realm_name
     dm_password = options.dm_password
     host_name = options.host_name

--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -69,10 +69,7 @@ from ipaserver.install import installutils
 from ipaserver.install import ldapupdate
 from ipaserver.install import replication
 from ipaserver.install import sysupgrade
-# pylint: disable=unused-import
-from ipaserver.install.dogtaginstance import (export_kra_agent_pem,
-                                              DogtagInstance)
-# pylint: enable=unused-import
+from ipaserver.install.dogtaginstance import DogtagInstance
 from ipaserver.plugins import ldap2
 
 # Python 3 rename. The package is available in "six.moves.http_client", but

--- a/ipaserver/install/cainstance.py
+++ b/ipaserver/install/cainstance.py
@@ -63,13 +63,16 @@ from ipapython.ipa_log_manager import log_mgr,\
 from ipapython.secrets.kem import IPAKEMKeys
 
 from ipaserver.install import certs
+from ipaserver.install import custodiainstance
 from ipaserver.install import dsinstance
 from ipaserver.install import installutils
 from ipaserver.install import ldapupdate
 from ipaserver.install import replication
 from ipaserver.install import sysupgrade
+# pylint: disable=unused-import
 from ipaserver.install.dogtaginstance import (export_kra_agent_pem,
                                               DogtagInstance)
+# pylint: enable=unused-import
 from ipaserver.plugins import ldap2
 
 # Python 3 rename. The package is available in "six.moves.http_client", but
@@ -323,7 +326,6 @@ class CAInstance(DogtagInstance):
         self.csr_file = None
         self.cert_file = None
         self.cert_chain_file = None
-        self.create_ra_agent_db = True
 
         if realm is not None:
             self.canickname = get_ca_nickname(realm)
@@ -344,7 +346,8 @@ class CAInstance(DogtagInstance):
                            cert_file=None, cert_chain_file=None,
                            master_replication_port=None,
                            subject_base=None, ca_signing_algorithm=None,
-                           ca_type=None, ra_p12=None, promote=False):
+                           ca_type=None, ra_p12=None, ra_only=False,
+                           promote=False):
         """Create a CA instance.
 
            To create a clone, pass in pkcs12_info.
@@ -388,62 +391,73 @@ class CAInstance(DogtagInstance):
             self.cert_chain_file = cert_chain_file
             self.external = 2
 
-        self.step("creating certificate server user", create_ca_user)
-        if promote:
-            # Setup Database
-            self.step("creating certificate server db", self.__create_ds_db)
-            self.step("setting up initial replication", self.__setup_replication)
-            self.step("creating installation admin user", self.setup_admin)
-        self.step("configuring certificate server instance",
-                  self.__spawn_instance)
-        self.step("stopping certificate server instance to update CS.cfg", self.stop_instance)
-        self.step("backing up CS.cfg", self.backup_config)
-        self.step("disabling nonces", self.__disable_nonce)
-        self.step("set up CRL publishing", self.__enable_crl_publish)
-        self.step("enable PKIX certificate path discovery and validation", self.enable_pkix)
-        if promote:
-            self.step("destroying installation admin user", self.teardown_admin)
-        self.step("starting certificate server instance", self.start_instance)
+        if self.clone:
+            cert_db = certs.CertDB(self.realm)
+            has_ra_cert = (cert_db.get_cert_from_db('ipaCert') != '')
+        else:
+            has_ra_cert = False
+
+        if not ra_only:
+            self.step("creating certificate server user", create_ca_user)
+            if promote:
+                # Setup Database
+                self.step("creating certificate server db", self.__create_ds_db)
+                self.step("setting up initial replication", self.__setup_replication)
+                self.step("creating installation admin user", self.setup_admin)
+            self.step("configuring certificate server instance",
+                      self.__spawn_instance)
+            self.step("stopping certificate server instance to update CS.cfg", self.stop_instance)
+            self.step("backing up CS.cfg", self.backup_config)
+            self.step("disabling nonces", self.__disable_nonce)
+            self.step("set up CRL publishing", self.__enable_crl_publish)
+            self.step("enable PKIX certificate path discovery and validation", self.enable_pkix)
+            if promote:
+                self.step("destroying installation admin user", self.teardown_admin)
+            self.step("starting certificate server instance", self.start_instance)
         # Step 1 of external is getting a CSR so we don't need to do these
         # steps until we get a cert back from the external CA.
         if self.external != 1:
-            self.step("importing CA chain to RA certificate database", self.__import_ca_chain)
-            self.step("setting up signing cert profile", self.__setup_sign_profile)
-            self.step("setting audit signing renewal to 2 years", self.set_audit_renewal)
-            if not self.clone:
-                self.step("restarting certificate server", self.restart_instance)
-                self.step("requesting RA certificate from CA", self.__request_ra_certificate)
-                self.step("issuing RA agent certificate", self.__issue_ra_cert)
-                self.step("adding RA agent as a trusted user", self.__create_ca_agent)
-            elif not promote and ra_p12 is not None:
-                self.step("importing RA certificate from PKCS #12 file",
-                          lambda: self.import_ra_cert(ra_p12, configure_renewal=False))
-            self.step("authorizing RA to modify profiles", configure_profiles_acl)
-            self.step("authorizing RA to manage lightweight CAs",
-                      configure_lightweight_ca_acls)
-            self.step("Ensure lightweight CAs container exists",
-                      ensure_lightweight_cas_container)
-            self.step("configure certmonger for renewals", self.configure_certmonger_renewal)
-            self.step("configure certificate renewals", self.configure_renewal)
-            if not self.clone:
+            if not has_ra_cert:
+                if not self.clone:
+                    self.step("requesting RA certificate from CA", self.__request_ra_certificate)
+                    self.step("issuing RA agent certificate", self.__issue_ra_cert)
+                elif promote:
+                    self.step("Importing RA key", self.__import_ra_key)
+                else:
+                    self.step("importing RA certificate from PKCS #12 file",
+                              lambda: self.import_ra_cert(ra_p12))
+                self.step("configure certmonger for renewals", self.configure_certmonger_renewal)
                 self.step("configure RA certificate renewal", self.configure_agent_renewal)
-            self.step("configure Server-Cert certificate renewal", self.track_servercert)
-            self.step("Configure HTTP to proxy connections",
-                      self.http_proxy)
-            self.step("restarting certificate server", self.restart_instance)
-            if not promote:
-                self.step("migrating certificate profiles to LDAP",
-                          migrate_profiles_to_ldap)
-                self.step("importing IPA certificate profiles",
-                          import_included_profiles)
-                self.step("adding default CA ACL", ensure_default_caacl)
-                self.step("adding 'ipa' CA entry", ensure_ipa_authority_entry)
-            self.step("updating IPA configuration", update_ipa_conf)
+            if not ra_only:
+                self.step("importing CA chain to RA certificate database", self.__import_ca_chain)
+                self.step("setting up signing cert profile", self.__setup_sign_profile)
+                self.step("setting audit signing renewal to 2 years", self.set_audit_renewal)
+                self.step("restarting certificate server", self.restart_instance)
+                if not self.clone:
+                    self.step("adding RA agent as a trusted user", self.__create_ca_agent)
+                self.step("authorizing RA to modify profiles", configure_profiles_acl)
+                self.step("authorizing RA to manage lightweight CAs",
+                          configure_lightweight_ca_acls)
+                self.step("Ensure lightweight CAs container exists",
+                          ensure_lightweight_cas_container)
+                self.step("configure certificate renewals", self.configure_renewal)
+                self.step("configure Server-Cert certificate renewal", self.track_servercert)
+                self.step("Configure HTTP to proxy connections",
+                          self.http_proxy)
+                self.step("restarting certificate server", self.restart_instance)
+                if not promote:
+                    self.step("migrating certificate profiles to LDAP",
+                              migrate_profiles_to_ldap)
+                    self.step("importing IPA certificate profiles",
+                              import_included_profiles)
+                    self.step("adding default CA ACL", ensure_default_caacl)
+                    self.step("adding 'ipa' CA entry", ensure_ipa_authority_entry)
+                self.step("updating IPA configuration", update_ipa_conf)
 
-            self.step("enabling CA instance", self.__enable_instance)
+                self.step("enabling CA instance", self.__enable_instance)
 
-            self.step("configuring certmonger renewal for lightweight CAs",
-                      self.__add_lightweight_ca_tracking_requests)
+                self.step("configuring certmonger renewal for lightweight CAs",
+                          self.__add_lightweight_ca_tracking_requests)
 
         self.start_creation(runtime=210)
 
@@ -498,9 +512,6 @@ class CAInstance(DogtagInstance):
         config.set("CA", "pki_ds_password", self.dm_password)
         config.set("CA", "pki_ds_base_dn", self.basedn)
         config.set("CA", "pki_ds_database", "ipaca")
-
-        if not self.create_ra_agent_db and not self.clone:
-            self._use_ldaps_during_spawn(config)
 
         # Certificate subject DN's
         config.set("CA", "pki_subsystem_subject_dn",
@@ -737,9 +748,7 @@ class CAInstance(DogtagInstance):
         finally:
             os.remove(agent_name)
 
-        export_kra_agent_pem()
-
-    def import_ra_cert(self, rafile, configure_renewal=True):
+    def import_ra_cert(self, rafile):
         """
         Cloned RAs will use the same RA agent cert as the master so we
         need to import from a PKCS#12 file.
@@ -755,10 +764,10 @@ class CAInstance(DogtagInstance):
         finally:
             os.remove(agent_name)
 
-        if configure_renewal:
-            self.configure_agent_renewal()
-
-        export_kra_agent_pem()
+    def __import_ra_key(self):
+        custodia = custodiainstance.CustodiaInstance(host_name=self.fqdn,
+                                                     realm=self.realm)
+        custodia.import_ra_key(self.master_host)
 
     def __create_ca_agent(self):
         """

--- a/ipaserver/install/certs.py
+++ b/ipaserver/install/certs.py
@@ -658,7 +658,6 @@ class CertDB(object):
         return self.nssdb.export_pem_cert(nickname, location)
 
     def request_service_cert(self, nickname, principal, host, pwdconf=False):
-        self.create_from_cacert(paths.IPA_CA_CRT)
         if pwdconf:
             self.create_password_conf()
         reqid = certmonger.request_cert(nssdb=self.secdir,

--- a/ipaserver/install/custodiainstance.py
+++ b/ipaserver/install/custodiainstance.py
@@ -22,7 +22,7 @@ import pwd
 
 
 class CustodiaInstance(SimpleServiceInstance):
-    def __init__(self, host_name=None, realm=None, ca_is_configured=True):
+    def __init__(self, host_name=None, realm=None):
         super(CustodiaInstance, self).__init__("ipa-custodia")
         self.config_file = paths.IPA_CUSTODIA_CONF
         self.server_keys = os.path.join(paths.IPA_CUSTODIA_CONF_DIR,
@@ -30,7 +30,6 @@ class CustodiaInstance(SimpleServiceInstance):
         self.ldap_uri = None
         self.fqdn = host_name
         self.realm = realm
-        self.ca_is_configured = ca_is_configured
         self.__CustodiaClient = functools.partial(
             CustodiaClient,
             client_service='host@%s' % self.fqdn,
@@ -87,8 +86,6 @@ class CustodiaInstance(SimpleServiceInstance):
 
         self.step("Generating ipa-custodia config file", self.__config_file)
         self.step("Generating ipa-custodia keys", self.__gen_keys)
-        if self.ca_is_configured:
-            self.step("Importing RA Key", self.__import_ra_key)
         super(CustodiaInstance, self).create_instance(gensvc_name='KEYS',
                                                       fqdn=self.fqdn,
                                                       ldap_suffix=suffix,
@@ -107,8 +104,8 @@ class CustodiaInstance(SimpleServiceInstance):
                                         sub_dict=sub_dict)
         updater.update([os.path.join(paths.UPDATES_DIR, '73-custodia.update')])
 
-    def __import_ra_key(self):
-        cli = self.__CustodiaClient(server=self.master_host_name)
+    def import_ra_key(self, master_host_name):
+        cli = self.__CustodiaClient(server=master_host_name)
         cli.fetch_key('ra/ipaCert')
 
     def import_dm_password(self, master_host_name):

--- a/ipaserver/install/dsinstance.py
+++ b/ipaserver/install/dsinstance.py
@@ -1235,6 +1235,7 @@ class DsInstance(service.Service):
         subject = DN(('O', self.realm))
         nssdb_dir = config_dirname(self.serverid)
         db = certs.CertDB(self.realm, nssdir=nssdb_dir, subject_base=subject)
+        db.create_from_cacert(paths.IPA_CA_CRT)
         db.request_service_cert(self.nickname, self.principal, self.fqdn)
         db.create_pin_file()
 

--- a/ipaserver/install/httpinstance.py
+++ b/ipaserver/install/httpinstance.py
@@ -362,6 +362,8 @@ class HTTPInstance(service.Service):
 
             # We only handle one server cert
             nickname = server_certs[0][0]
+            if nickname == 'ipaCert':
+                nickname = server_certs[1][0]
             self.dercert = db.get_cert_from_db(nickname, pem=False)
 
             if self.ca_is_configured:

--- a/ipaserver/install/ipa_kra_install.py
+++ b/ipaserver/install/ipa_kra_install.py
@@ -204,6 +204,8 @@ class KRAInstaller(KRAInstall):
                     self.options)
                 config.kra_host_name = config.master_host_name
 
+            config.setup_kra = True
+
             if config.subject_base is None:
                 attrs = conn.get_ipa_config()
                 config.subject_base = attrs.get('ipacertificatesubjectbase')[0]

--- a/ipaserver/install/krainstance.py
+++ b/ipaserver/install/krainstance.py
@@ -79,7 +79,7 @@ class KRAInstance(DogtagInstance):
 
     def configure_instance(self, realm_name, host_name, dm_password,
                            admin_password, pkcs12_info=None, master_host=None,
-                           subject_base=None, promote=False):
+                           subject_base=None, ra_only=False, promote=False):
         """Create a KRA instance.
 
            To create a clone, pass in pkcs12_info.
@@ -99,35 +99,38 @@ class KRAInstance(DogtagInstance):
         self.realm = realm_name
         self.suffix = ipautil.realm_to_suffix(realm_name)
 
-        # Confirm that a KRA does not already exist
-        if self.is_installed():
-            raise RuntimeError(
-                "KRA already installed.")
-        # Confirm that a Dogtag 10 CA instance already exists
-        ca = cainstance.CAInstance(self.realm, certs.NSS_DIR)
-        if not ca.is_installed():
-            raise RuntimeError(
-                "KRA configuration failed.  "
-                "A Dogtag CA must be installed first")
+        if not ra_only:
+            # Confirm that a KRA does not already exist
+            if self.is_installed():
+                raise RuntimeError(
+                    "KRA already installed.")
+            # Confirm that a Dogtag 10 CA instance already exists
+            ca = cainstance.CAInstance(self.realm, certs.NSS_DIR)
+            if not ca.is_installed():
+                raise RuntimeError(
+                    "KRA configuration failed.  "
+                    "A Dogtag CA must be installed first")
 
-        if promote:
-            self.step("creating installation admin user", self.setup_admin)
-        self.step("configuring KRA instance", self.__spawn_instance)
-        if not self.clone:
-            self.step("create KRA agent",
-                      self.__create_kra_agent)
-        if promote:
-            self.step("destroying installation admin user", self.teardown_admin)
-        self.step("restarting KRA", self.restart_instance)
-        self.step("configure certmonger for renewals",
-                  self.configure_certmonger_renewal)
-        self.step("configure certificate renewals", self.configure_renewal)
-        self.step("configure HTTP to proxy connections",
-                  self.http_proxy)
-        self.step("add vault container", self.__add_vault_container)
-        self.step("apply LDAP updates", self.__apply_updates)
+            if promote:
+                self.step("creating installation admin user", self.setup_admin)
+            self.step("configuring KRA instance", self.__spawn_instance)
+            if not self.clone:
+                self.step("create KRA agent",
+                          self.__create_kra_agent)
+        self.step("exporting KRA agent cert", export_kra_agent_pem)
+        if not ra_only:
+            if promote:
+                self.step("destroying installation admin user", self.teardown_admin)
+            self.step("restarting KRA", self.restart_instance)
+            self.step("configure certmonger for renewals",
+                      self.configure_certmonger_renewal)
+            self.step("configure certificate renewals", self.configure_renewal)
+            self.step("configure HTTP to proxy connections",
+                      self.http_proxy)
+            self.step("add vault container", self.__add_vault_container)
+            self.step("apply LDAP updates", self.__apply_updates)
 
-        self.step("enabling KRA instance", self.__enable_instance)
+            self.step("enabling KRA instance", self.__enable_instance)
 
         self.start_creation(runtime=126)
 

--- a/ipaserver/install/server/replicainstall.py
+++ b/ipaserver/install/server/replicainstall.py
@@ -35,7 +35,7 @@ from ipalib.util import (
 import ipaclient.ipachangeconf
 import ipaclient.ntpconf
 from ipaserver.install import (
-    bindinstance, ca, cainstance, certs, dns, dsinstance, httpinstance,
+    bindinstance, ca, certs, dns, dsinstance, httpinstance,
     installutils, kra, krbinstance, memcacheinstance,
     ntpinstance, otpdinstance, custodiainstance, service)
 from ipaserver.install.installutils import (
@@ -718,13 +718,15 @@ def install_check(installer):
             root_logger.debug('No IPA DNS servers, '
                               'skipping forward/reverse resolution check')
 
+        kra_enabled = remote_api.Command.kra_is_enabled()['result']
+
         if ca_enabled:
             options.realm_name = config.realm_name
             options.host_name = config.host_name
             options.subject = config.subject_base
             ca.install_check(False, config, options)
 
-        if config.setup_kra:
+        if kra_enabled:
             try:
                 kra.install_check(remote_api, config, options)
             except RuntimeError as e:
@@ -768,6 +770,7 @@ def install_check(installer):
             ca_cert_file=cafile)
 
     installer._ca_enabled = ca_enabled
+    installer._kra_enabled = kra_enabled
     installer._remote_api = remote_api
     installer._fstore = fstore
     installer._sstore = sstore
@@ -778,6 +781,7 @@ def install_check(installer):
 def install(installer):
     options = installer
     ca_enabled = installer._ca_enabled
+    kra_enabled = installer._kra_enabled
     fstore = installer._fstore
     sstore = installer._sstore
     config = installer._config
@@ -840,9 +844,6 @@ def install(installer):
     otpd.create_instance('OTPD', config.host_name, config.dirman_password,
                          ipautil.realm_to_suffix(config.realm_name))
 
-    if ca_enabled:
-        cainstance.export_kra_agent_pem()
-
     custodia = custodiainstance.CustodiaInstance(config.host_name,
                                                  config.realm_name)
     custodia.create_instance(config.dirman_password)
@@ -855,11 +856,8 @@ def install(installer):
     service.print_msg("Applying LDAP updates")
     ds.apply_updates()
 
-    if options.setup_kra:
+    if kra_enabled:
         kra.install(api, config, options)
-    else:
-        service.print_msg("Restarting the directory server")
-        ds.restart()
 
     service.print_msg("Restarting the KDC")
     krb.restart()
@@ -1275,12 +1273,17 @@ def promote_check(installer):
                                   "custom certificates.")
                 raise ScriptError(rval=3)
 
-        config.kra_host_name = service.find_providing_server(
+        kra_host = service.find_providing_server(
                 'KRA', conn, config.kra_host_name)
-        if options.setup_kra and config.kra_host_name is None:
-            root_logger.error("There is no KRA server in the domain, can't "
-                              "setup a KRA clone")
-            raise ScriptError(rval=3)
+        if kra_host is not None:
+            config.kra_host_name = kra_host
+            kra_enabled = True
+        else:
+            if options.setup_kra:
+                root_logger.error("There is no KRA server in the domain, "
+                                  "can't setup a KRA clone")
+                raise ScriptError(rval=3)
+            kra_enabled = False
 
         if ca_enabled:
             options.realm_name = config.realm_name
@@ -1288,7 +1291,7 @@ def promote_check(installer):
             options.subject = config.subject_base
             ca.install_check(False, config, options)
 
-        if config.setup_kra:
+        if kra_enabled:
             try:
                 kra.install_check(remote_api, config, options)
             except RuntimeError as e:
@@ -1343,6 +1346,7 @@ def promote_check(installer):
         raise RuntimeError("CA cert file is not available.")
 
     installer._ca_enabled = ca_enabled
+    installer._kra_enabled = kra_enabled
     installer._fstore = fstore
     installer._sstore = sstore
     installer._config = config
@@ -1360,6 +1364,7 @@ def promote_check(installer):
 def promote(installer):
     options = installer
     ca_enabled = installer._ca_enabled
+    kra_enabled = installer._kra_enabled
     fstore = installer._fstore
     sstore = installer._sstore
     config = installer._config
@@ -1470,9 +1475,6 @@ def promote(installer):
                                                  config.realm_name)
     custodia.create_replica(config.master_host_name)
 
-    if installer._ca_enabled:
-        cainstance.export_kra_agent_pem()
-
     install_krb(
         config,
         setup_pkinit=not options.no_pkinit,
@@ -1499,7 +1501,7 @@ def promote(installer):
         options.dm_password = config.dirman_password
         ca.install(False, config, options)
 
-    if options.setup_kra:
+    if kra_enabled:
         kra.install(api, config, options)
 
     custodia.import_dm_password(config.master_host_name)


### PR DESCRIPTION
This fixes wrong permissions on /etc/httpd/alias after DL1 replica installation.