### PR TITLE
fix incorrect invocation of ipa-getkeytab during DL0 host enrollment

### DIFF
--- a/ipaserver/install/server/replicainstall.py
+++ b/ipaserver/install/server/replicainstall.py
@@ -526,7 +526,7 @@ def enroll_dl0_replica(installer, fstore, remote_api, debug=False):
             '-D', unicode(DIRMAN_DN),
             '-w', config.dirman_password,
             '-k', paths.KRB5_KEYTAB,
-            '-c', os.path.join(config.dir, 'ca.crt')
+            '--cacert', os.path.join(config.dir, 'ca.crt')
         ]
         ipautil.run(getkeytab_args, nolog=(config.dirman_password,))
 


### PR DESCRIPTION
https://fedorahosted.org/freeipa/ticket/6434